### PR TITLE
Add ignore for generated outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Project specific outputs
+stockcall_duration_extractor/outputs/


### PR DESCRIPTION
## Summary
- add ignore rule for `stockcall_duration_extractor/outputs`
- keep common Python caches ignored

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ade48e030832f9638ae7aae06614c