### PR TITLE
Add fuzzy term matching

### DIFF
--- a/stockcall_duration_extractor/extractor/matchers/__init__.py
+++ b/stockcall_duration_extractor/extractor/matchers/__init__.py
@@ -1,0 +1,7 @@
+"""Pattern matchers for duration extraction."""
+
+from .literal_matcher import match_literal
+from .regex_matcher import match_regex
+from .fuzzy_matcher import match_fuzzy_terms
+
+__all__ = ["match_literal", "match_regex", "match_fuzzy_terms"]

--- a/stockcall_duration_extractor/extractor/matchers/fuzzy_matcher.py
+++ b/stockcall_duration_extractor/extractor/matchers/fuzzy_matcher.py
@@ -1,0 +1,32 @@
+"""Fuzzy term matcher."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional, Dict, Any
+
+
+def match_fuzzy_terms(sentences: Iterable[str], fuzzy_terms: Iterable) -> Optional[Dict[str, Any]]:
+    """Return match info if any fuzzy term is present."""
+    for sentence in sentences:
+        lower_sentence = sentence.lower()
+        for entry in fuzzy_terms:
+            if isinstance(entry, dict):
+                term = entry.get("term", "").lower()
+                mapped_value = entry.get("mapped_value")
+                unit = entry.get("unit")
+                confidence = entry.get("confidence")
+            else:
+                term = str(entry).lower()
+                mapped_value = None
+                unit = None
+                confidence = None
+
+            if term and term in lower_sentence:
+                return {
+                    "matched_sentence": sentence,
+                    "pattern": entry.get("term", term) if isinstance(entry, dict) else entry,
+                    "normalized_value": mapped_value,
+                    "unit": unit,
+                    "confidence": confidence,
+                }
+    return None

--- a/stockcall_duration_extractor/extractor/matchers/literal_matcher.py
+++ b/stockcall_duration_extractor/extractor/matchers/literal_matcher.py
@@ -1,0 +1,22 @@
+"""Literal pattern matcher."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional, Dict, Any
+
+
+def match_literal(sentences: Iterable[str], literals: Iterable[dict]) -> Optional[Dict[str, Any]]:
+    """Return match info if any literal pattern is found."""
+    for sentence in sentences:
+        lower_sentence = sentence.lower()
+        for entry in literals:
+            pat = entry.get("pattern", "").lower()
+            if pat and pat in lower_sentence:
+                return {
+                    "matched_sentence": sentence,
+                    "pattern": entry.get("pattern"),
+                    "normalized_value": entry.get("normalized_value"),
+                    "unit": entry.get("unit"),
+                    "confidence": entry.get("confidence"),
+                }
+    return None

--- a/stockcall_duration_extractor/extractor/matchers/regex_matcher.py
+++ b/stockcall_duration_extractor/extractor/matchers/regex_matcher.py
@@ -1,0 +1,43 @@
+"""Regex pattern matcher."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional, Dict, Any
+import re
+
+
+def match_regex(sentences: Iterable[str], regexes: Iterable[dict]) -> Optional[Dict[str, Any]]:
+    """Return match info if any regex pattern matches."""
+    for sentence in sentences:
+        for entry in regexes:
+            regex = entry.get("pattern", "")
+            if not regex:
+                continue
+            match = re.search(regex, sentence, flags=re.IGNORECASE)
+            if match:
+                group_idx = entry.get("extract_group", 1)
+                normalized_value = None
+                try:
+                    value_str = match.group(group_idx)
+                    normalized_value = int(value_str)
+                except (IndexError, ValueError, TypeError):
+                    continue
+
+                unit = entry.get("unit")
+                unit_group = entry.get("unit_group")
+                if unit_group is not None:
+                    try:
+                        unit = match.group(unit_group)
+                    except IndexError:
+                        pass
+                elif unit is None and match.lastindex and match.lastindex >= 2:
+                    unit = match.group(2)
+
+                return {
+                    "matched_sentence": sentence,
+                    "pattern": regex,
+                    "normalized_value": normalized_value,
+                    "unit": unit,
+                    "confidence": entry.get("confidence"),
+                }
+    return None

--- a/stockcall_duration_extractor/extractor/rule_engine.py
+++ b/stockcall_duration_extractor/extractor/rule_engine.py
@@ -3,66 +3,20 @@ from __future__ import annotations
 
 from typing import Iterable, Optional, Dict, Any
 
-import re
-
 from pattern_store.pattern_loader import get_patterns
+from .matchers import match_literal, match_regex, match_fuzzy_terms
 
 
 def match_duration_patterns(sentences: Iterable[str]) -> Optional[Dict[str, Any]]:
-    """Match duration patterns within the provided sentences.
-
-    This first checks for literal string patterns and then attempts regex based
-    patterns before falling back to fuzzy matching (not yet implemented).
-    """
+    """Match duration patterns within ``sentences`` using different matchers."""
     patterns = get_patterns()
-    literals = patterns.get("literal_patterns", [])
-    regexes = patterns.get("regex_patterns", [])
 
-    for sentence in sentences:
-        lower_sentence = sentence.lower()
-        for entry in literals:
-            pat = entry.get("pattern", "").lower()
-            if pat and pat in lower_sentence:
-                return {
-                    "matched_sentence": sentence,
-                    "pattern": entry.get("pattern"),
-                    "normalized_value": entry.get("normalized_value"),
-                    "unit": entry.get("unit"),
-                    "confidence": entry.get("confidence"),
-                }
+    result = match_literal(sentences, patterns.get("literal_patterns", []))
+    if result:
+        return result
 
-    # Try regex-based patterns
-    for sentence in sentences:
-        for entry in regexes:
-            regex = entry.get("pattern", "")
-            if not regex:
-                continue
-            match = re.search(regex, sentence, flags=re.IGNORECASE)
-            if match:
-                group_idx = entry.get("extract_group", 1)
-                normalized_value = None
-                try:
-                    value_str = match.group(group_idx)
-                    normalized_value = int(value_str)
-                except (IndexError, ValueError, TypeError):
-                    continue
+    result = match_regex(sentences, patterns.get("regex_patterns", []))
+    if result:
+        return result
 
-                unit = entry.get("unit")
-                unit_group = entry.get("unit_group")
-                if unit_group is not None:
-                    try:
-                        unit = match.group(unit_group)
-                    except IndexError:
-                        pass
-                elif unit is None and match.lastindex and match.lastindex >= 2:
-                    unit = match.group(2)
-
-                return {
-                    "matched_sentence": sentence,
-                    "pattern": regex,
-                    "normalized_value": normalized_value,
-                    "unit": unit,
-                    "confidence": entry.get("confidence"),
-                }
-
-    return None
+    return match_fuzzy_terms(sentences, patterns.get("fuzzy_terms", []))

--- a/stockcall_duration_extractor/pattern_store/patterns_library.yaml
+++ b/stockcall_duration_extractor/pattern_store/patterns_library.yaml
@@ -25,3 +25,7 @@ regex_patterns:
 fuzzy_terms:
   - approximately
   - about
+  - around
+  - roughly
+  - nearly
+  - "close to"


### PR DESCRIPTION
## Summary
- support fuzzy term matching in rule_engine
- add matchers folder with literal, regex, and fuzzy matchers
- expand fuzzy terms

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python stockcall_duration_extractor/main.py > /tmp/main_output.txt`

------
https://chatgpt.com/codex/tasks/task_e_688b525b2cbc832fa9c8ef0d97790117